### PR TITLE
Added Time Picker dialog fragment for user to edit count down time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /local.properties
 /.idea/caches
 /.idea/libraries
+.idea/misc.xml
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,15 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="app/src/main/res/layout/dialog_count_down_picker.xml" value="0.43854166666666666" />
+        <entry key="app/src/main/res/layout/fragment_fmt.xml" value="0.43854166666666666" />
+      </map>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_11
     }
 }
 
@@ -42,6 +42,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation "androidx.navigation:navigation-fragment-ktx:$androidx_navigation_version"

--- a/app/src/main/java/com/github/muellerma/tabletoptools/ui/dialog/CountDownPickerDialog.kt
+++ b/app/src/main/java/com/github/muellerma/tabletoptools/ui/dialog/CountDownPickerDialog.kt
@@ -1,0 +1,71 @@
+package com.github.muellerma.tabletoptools.ui.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.NumberPicker
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.github.muellerma.tabletoptools.R
+
+class CountDownPickerDialog : DialogFragment() {
+
+    private var minutesAndSeconds: Pair<Int, Int> = Pair(5, 0)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val v = inflater.inflate(R.layout.dialog_count_down_picker, container, false)
+        arguments?.apply {
+            minutesAndSeconds = convertMillisToMinutesAndSeconds(getLong(MILLIS_BUNDLE_KEY))
+        }
+        val minutes = v.findViewById<NumberPicker>(R.id.minute_number_picker).apply {
+            minValue = MIN_TIME
+            maxValue = MAX_TIME
+            value = minutesAndSeconds.first
+        }
+        val seconds = v.findViewById<NumberPicker>(R.id.second_number_picker).apply {
+            minValue = MIN_TIME
+            maxValue = MAX_TIME
+            value = minutesAndSeconds.second
+        }
+
+        val but = v.findViewById<Button>(R.id.button)
+        but.setOnClickListener {
+            setFragmentResult(
+                RESULT_KEY,
+                bundleOf(MINUTE_KEY to minutes.value, SECOND_KEY to seconds.value)
+            )
+            dismiss()
+        }
+        return v
+    }
+
+    private fun convertMillisToMinutesAndSeconds(millis: Long): Pair<Int, Int> {
+        val minutes = millis / 1000 / 60
+        val seconds = millis / 1000 % 60
+        return Pair(minutes.toInt(), seconds.toInt())
+    }
+
+    companion object {
+        fun createBundle(millis: Long): Bundle {
+            return bundleOf(
+                MILLIS_BUNDLE_KEY to millis
+            )
+        }
+
+        private const val MILLIS_BUNDLE_KEY = "MILLIS_BUNDLE_KEY"
+
+        const val MIN_TIME = 0
+        const val MAX_TIME = 59
+        const val TAG = "CountDownPickerDialog"
+        const val RESULT_KEY = "TIME_RESULT_KEY"
+        const val MINUTE_KEY = "MINUTE_KEY"
+        const val SECOND_KEY = "SECOND_KEY"
+    }
+}

--- a/app/src/main/java/com/github/muellerma/tabletoptools/ui/fragments/CountDownFragment.kt
+++ b/app/src/main/java/com/github/muellerma/tabletoptools/ui/fragments/CountDownFragment.kt
@@ -21,7 +21,7 @@ import com.github.muellerma.tabletoptools.ui.dialog.CountDownPickerDialog
 import java.util.concurrent.TimeUnit
 
 
-class FMTFragment : AbstractBaseFragment() {
+class CountDownFragment : AbstractBaseFragment() {
     private lateinit var timerView1: TextView
     private lateinit var timerView2: TextView
     private lateinit var startButton: Button
@@ -187,7 +187,7 @@ class FMTFragment : AbstractBaseFragment() {
     }
 
     companion object {
-        private var TAG = FMTFragment::class.java.simpleName
+        private var TAG = CountDownFragment::class.java.simpleName
         private const val PREVIOUS_MILLIS = "PREVIOUS_MILLIS"
         private const val DEFAULT_TIMER = 5 * 60 * 1000L
     }

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_count_down_picker.xml
+++ b/app/src/main/res/layout/dialog_count_down_picker.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp"
+        android:gravity="center"
+        android:orientation="vertical">
+
+    <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+        <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:gravity="center"
+                android:orientation="vertical">
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:textSize="18sp"
+                    android:text="@string/fmt_timer_select_min" />
+
+            <NumberPicker
+                    android:id="@+id/minute_number_picker"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:gravity="center"
+                android:orientation="vertical">
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:textSize="18sp"
+                    android:text="@string/fmt_timer_select_sec" />
+
+            <NumberPicker
+                    android:id="@+id/second_number_picker"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <Button
+            android:id="@+id/button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/fmt_timer_confirm" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_fmt.xml
+++ b/app/src/main/res/layout/fragment_fmt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -47,14 +46,30 @@
         <com.google.android.material.button.MaterialButton
                 android:id="@+id/reset_button"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginEnd="8dp"
                 android:text="@string/fmt_timer_reset"
                 android:visibility="invisible"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/edit_time_button"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/timer_view2"
+                tools:visibility="visible"
+                android:layout_marginBottom="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/edit_time_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:text="@string/fmt_timer_edit"
+                app:icon="@drawable/ic_edit"
+                android:visibility="visible"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/reset_button"
                 app:layout_constraintBottom_toTopOf="@id/timer_view2"
                 tools:visibility="visible"
                 android:layout_marginBottom="8dp" />

--- a/app/src/main/res/layout/fragment_fmt.xml
+++ b/app/src/main/res/layout/fragment_fmt.xml
@@ -6,7 +6,7 @@
         android:layout_height="match_parent"
         android:fillViewport="true"
         android:keepScreenOn="true"
-        tools:context=".ui.fragments.FMTFragment">
+        tools:context=".ui.fragments.CountDownFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -24,7 +24,7 @@
 
     <fragment
             android:id="@+id/nav_fmt"
-            android:name="com.github.muellerma.tabletoptools.ui.fragments.FMTFragment"
+            android:name="com.github.muellerma.tabletoptools.ui.fragments.CountDownFragment"
             android:label="@string/menu_fmt"
             tools:layout="@layout/fragment_fmt" />
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -38,6 +38,10 @@
     <string name="fmt_timer_start">Démarrer</string>
     <string name="fmt_timer_pause">Pause</string>
     <string name="fmt_timer_reset">Réinitialiser</string>
+    <string name="fmt_timer_edit">Éditer</string>
+    <string name="fmt_timer_confirm">Confirmer</string>
+    <string name="fmt_timer_select_min">Min</string>
+    <string name="fmt_timer_select_sec">Sec</string>
 
     <!-- Buzzers -->
     <string name="menu_buzzers">Buzzers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,10 @@
     <string name="fmt_timer_start">Start</string>
     <string name="fmt_timer_pause">Pause</string>
     <string name="fmt_timer_reset">Reset</string>
+    <string name="fmt_timer_edit">Edit</string>
+    <string name="fmt_timer_confirm">Confirm</string>
+    <string name="fmt_timer_select_min">Min</string>
+    <string name="fmt_timer_select_sec">Sec</string>
 
     <!-- Buzzers -->
     <string name="menu_buzzers">Buzzers</string>


### PR DESCRIPTION
Addresses this issue: #57 

Here is what I did:
* Changed the `FMTFragment` name to be `CountDownFragment` 
* Added an edit button to the `CountDownFragment` screen
* Added a dialog fragment to open when user clicks edit button
* In the dialog fragment user can change minutes and seconds for the countdown
* when user clicks the confirm button the time is changed in the `CountDownFragment` 
* AND the time is also saved to shared preferences so that this time will always be reloaded when the user returns