### PR TITLE
bumped version up

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.androidx_navigation_version = "2.6.0"
+    ext.androidx_navigation_version = "2.7.3"
     ext.androidx_lifecycle_version = "2.6.2"
 }
 
@@ -56,7 +56,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.core:core-ktx:1.10.1"
+    implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.appcompat:appcompat:1.6.1"
     implementation "androidx.fragment:fragment-ktx:1.6.1"
     implementation "com.google.android.material:material:1.9.0"


### PR DESCRIPTION
solves #250

Bumps androidx.core:core-ktx from 1.10.1 to 1.12.0.
Bumps androidx_navigation_version from 2.6.0 to 2.7.3.
Updates androidx.navigation:navigation-fragment-ktx from 2.6.0 to 2.7.3

Updates androidx.navigation:navigation-ui-ktx from 2.6.0 to 2.7.3